### PR TITLE
feat: use neutral backgrounds for dark theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply bg-white text-gray-900;
+  @apply bg-neutral-900 text-white;
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -4,7 +4,15 @@ import { cn } from "@/lib/utils";
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 function Card({ className, ...props }: CardProps) {
-  return <div className={cn("rounded-lg border bg-white p-6", className)} {...props} />;
+  return (
+    <div
+      className={cn(
+        "rounded-lg border bg-neutral-900 p-6 text-white",
+        className
+      )}
+      {...props}
+    />
+  );
 }
 
 function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -28,14 +28,14 @@ const DialogContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-md bg-white p-6 shadow-lg",
+        <DialogPrimitive.Content
+          ref={ref}
+          className={cn(
+        "fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-md bg-neutral-900 p-6 text-white shadow-lg",
         className
-      )}
-      {...props}
-    >
+          )}
+          {...props}
+        >
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100">
         <X className="h-4 w-4" />

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -30,7 +30,7 @@ const SheetContent = React.forwardRef<
     <SheetPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed right-0 top-0 z-50 flex h-full w-80 flex-col border-l bg-white p-6 shadow-lg",
+        "fixed right-0 top-0 z-50 flex h-full w-80 flex-col border-l bg-neutral-900 p-6 text-white shadow-lg",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- switch card, dialog, and sheet components to neutral dark backgrounds with white text for dark theme support
- set global body styles to use a dark neutral background and white text

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5533c8688320a2ee032c2c38c5fa