### PR TITLE
Use image icons for map nodes

### DIFF
--- a/public/icons/rp.svg
+++ b/public/icons/rp.svg
@@ -1,3 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-  <circle cx="12" cy="12" r="10" fill="#000"/>
+<svg width="24" height="24" viewBox="0 0 24 24"
+     xmlns="http://www.w3.org/2000/svg" aria-labelledby="title"
+     fill="none">
+  <title>Распределительный пункт (РП)</title>
+  <g stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <!-- ввод сверху (вводные кабели/шины) -->
+    <line x1="8"  y1="5" x2="8"  y2="6.5"/>
+    <line x1="12" y1="4.5" x2="12" y2="6.5"/>
+    <line x1="16" y1="5" x2="16" y2="6.5"/>
+
+    <!-- корпус шкафа -->
+    <rect x="4" y="6.5" width="16" height="12.5" rx="1.5"/>
+
+    <!-- разделение на двери -->
+    <line x1="12.5" y1="6.5" x2="12.5" y2="19"/>
+
+    <!-- ручка двери -->
+    <line x1="14.2" y1="13" x2="15.2" y2="13"/>
+
+    <!-- вентиляционные жалюзи (левая дверь, верх) -->
+    <line x1="6.5" y1="9"   x2="10.5" y2="9"/>
+    <line x1="6.5" y1="10.5" x2="10.5" y2="10.5"/>
+
+    <!-- знак молнии (предупреждение) -->
+    <path d="M8 12.2 L10 16.5 L6 16.5 Z"/>
+    <path d="M8 13.2 l-0.8 1.4 h0.8 l-0.6 1.6"/>
+  </g>
 </svg>

--- a/public/icons/rp.svg
+++ b/public/icons/rp.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <circle cx="12" cy="12" r="10" fill="#000"/>
+</svg>

--- a/public/icons/support.svg
+++ b/public/icons/support.svg
@@ -1,3 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-  <path d="M12 2 L6 22 H18 L12 2 Z" fill="#000"/>
+<svg width="24" height="24" viewBox="0 0 24 24"
+     xmlns="http://www.w3.org/2000/svg" aria-labelledby="title"
+     fill="none">
+  <title>Power Transmission Tower (ЛЭП)</title>
+  <g stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <!-- crossarm -->
+    <line x1="5" y1="7" x2="19" y2="7"/>
+    <!-- insulator stubs -->
+    <line x1="8" y1="7" x2="8" y2="9"/>
+    <line x1="12" y1="7" x2="12" y2="9"/>
+    <line x1="16" y1="7" x2="16" y2="9"/>
+    <!-- conductors (left/right with slight sag) -->
+    <path d="M2 9 Q5 12 8 9"/>
+    <path d="M16 9 Q19 12 22 9"/>
+
+    <!-- tower legs & base -->
+    <line x1="12" y1="4" x2="6"  y2="20"/>
+    <line x1="12" y1="4" x2="18" y2="20"/>
+    <line x1="6"  y1="20" x2="18" y2="20"/>
+
+    <!-- lattice braces -->
+    <line x1="9.5" y1="12" x2="14.5" y2="12"/>
+    <line x1="8"   y1="16" x2="16"   y2="16"/>
+    <line x1="6"   y1="20" x2="14.5" y2="12"/>
+    <line x1="18"  y1="20" x2="9.5"  y2="12"/>
+    <line x1="8"   y1="16" x2="14.5" y2="12"/>
+    <line x1="16"  y1="16" x2="9.5"  y2="12"/>
+  </g>
 </svg>

--- a/public/icons/support.svg
+++ b/public/icons/support.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path d="M12 2 L6 22 H18 L12 2 Z" fill="#000"/>
+</svg>

--- a/public/icons/tp.svg
+++ b/public/icons/tp.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <rect x="4" y="4" width="16" height="16" fill="#000"/>
+</svg>

--- a/public/icons/tp.svg
+++ b/public/icons/tp.svg
@@ -1,3 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-  <rect x="4" y="4" width="16" height="16" fill="#000"/>
+<svg width="24" height="24" viewBox="0 0 24 24"
+     xmlns="http://www.w3.org/2000/svg" aria-labelledby="title"
+     fill="none">
+  <title>Transformer Substation Icon</title>
+  <g stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <!-- roof -->
+    <path d="M4 9L12 4L20 9"/>
+    <!-- body -->
+    <rect x="3" y="9" width="18" height="12" rx="2"/>
+    <!-- bushings on top -->
+    <line x1="7" y1="6" x2="7" y2="9"/>
+    <line x1="12" y1="5" x2="12" y2="9"/>
+    <line x1="17" y1="6" x2="17" y2="9"/>
+    <!-- transformer coils -->
+    <path d="M6 16 q1 -2 2 0 q1 2 2 0 q1 -2 2 0"/>
+    <path d="M12 16 q1 -2 2 0 q1 2 2 0 q1 -2 2 0"/>
+    <!-- door -->
+    <rect x="15.5" y="14" width="3" height="6" rx="0.5"/>
+    <!-- lightning on door -->
+    <path d="M17 15.6l-1.1 1.2h1l-.9 1.8"/>
+  </g>
 </svg>

--- a/src/features/electromap/ElectroMapMVP.tsx
+++ b/src/features/electromap/ElectroMapMVP.tsx
@@ -20,6 +20,12 @@ type StatusType = "working" | "maintenance" | "accident";
 type NodeType = "support" | "tp" | "rp";
 type LineType = "lep" | "kl";
 
+const nodeIcons: Record<NodeType, string> = {
+  support: "/icons/support.svg",
+  tp: "/icons/tp.svg",
+  rp: "/icons/rp.svg",
+};
+
 type Comment = { id: string; body: string; createdAt: string };
 
 type Node = {
@@ -352,7 +358,10 @@ export default function ElectroMapMVP() {
             <Placemark
               key={n.id}
               geometry={[n.lat, n.lon]}
-              options={{ iconColor: statusColors[n.status] }}
+              options={{
+                iconLayout: "default#image",
+                iconImageHref: nodeIcons[n.nodeType],
+              }}
               onClick={() => handlePlacemarkClick(n)}
             />
           ))}


### PR DESCRIPTION
## Summary
- add SVG icons for different node types
- show map nodes with custom icons instead of text

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ab57178b308320ae1fbfb0c9a82fee