### PR TITLE
feat: tint map icons by node status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+npm-debug.log*
+.DS_Store
+dist
+

--- a/public/icons/rp.svg
+++ b/public/icons/rp.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" fill="white"/>
+</svg>

--- a/public/icons/support.svg
+++ b/public/icons/support.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 2L3 22h4l2-4h6l2 4h4L12 2z" fill="white"/>
+</svg>

--- a/public/icons/tp.svg
+++ b/public/icons/tp.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="4" width="16" height="16" rx="2" fill="white"/>
+</svg>

--- a/src/features/electromap/ElectroMapMVP.tsx
+++ b/src/features/electromap/ElectroMapMVP.tsx
@@ -16,6 +16,12 @@ const statusColors: Record<StatusType, string> = {
   accident: "#ef4444",
 };
 
+const nodeIcons: Record<NodeType, string> = {
+  support: "/icons/support.svg",
+  tp: "/icons/tp.svg",
+  rp: "/icons/rp.svg",
+};
+
 type StatusType = "working" | "maintenance" | "accident";
 type NodeType = "support" | "tp" | "rp";
 type LineType = "lep" | "kl";
@@ -352,7 +358,12 @@ export default function ElectroMapMVP() {
             <Placemark
               key={n.id}
               geometry={[n.lat, n.lon]}
-              options={{ iconColor: statusColors[n.status] }}
+              options={{
+                iconLayout: "default#image",
+                iconImageHref: nodeIcons[n.nodeType],
+                iconColor: statusColors[n.status],
+                isMask: true,
+              }}
               onClick={() => handlePlacemarkClick(n)}
             />
           ))}


### PR DESCRIPTION
## Summary
- tint map node icons based on status color using maskable SVGs
- add basic SVG icon set for support, TP and RP nodes

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ab604a23fc8320b836405a49aa3c18