### PR TITLE
Allow Placemark mask option

### DIFF
--- a/src/features/electromap/ElectroMapMVP.tsx
+++ b/src/features/electromap/ElectroMapMVP.tsx
@@ -352,7 +352,7 @@ export default function ElectroMapMVP() {
             <Placemark
               key={n.id}
               geometry={[n.lat, n.lon]}
-              options={{ iconColor: statusColors[n.status] }}
+              options={{ iconColor: statusColors[n.status], isMask: true }}
               onClick={() => handlePlacemarkClick(n)}
             />
           ))}

--- a/types/react-yandex-maps.d.ts
+++ b/types/react-yandex-maps.d.ts
@@ -1,0 +1,7 @@
+import 'yandex-maps';
+
+declare module 'yandex-maps' {
+  interface IPlacemarkOptions {
+    isMask?: boolean;
+  }
+}


### PR DESCRIPTION
## Summary
- permit `isMask` in Yandex Placemark options via module augmentation
- apply `isMask` option when rendering Placemarks

## Testing
- `npm test`
- `npm run lint` *(fails: asks for ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6423760c8320989ef38bb672be2c